### PR TITLE
Add riverml as a forecaster

### DIFF
--- a/custom_components/hafo/config_flow.py
+++ b/custom_components/hafo/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for Home Assistant Forecaster integration."""
 
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
@@ -8,13 +8,22 @@ from homeassistant.helpers import selector
 import voluptuous as vol
 
 from .const import (
+    CONF_FORECAST_HOURS,
     CONF_FORECAST_TYPE,
     CONF_HISTORY_DAYS,
+    CONF_INPUT_ENTITIES,
+    CONF_OUTPUT_ENTITY,
+    CONF_RIVER_MODEL_TYPE,
     CONF_SOURCE_ENTITY,
+    DEFAULT_FORECAST_HOURS,
     DEFAULT_FORECAST_TYPE,
     DEFAULT_HISTORY_DAYS,
+    DEFAULT_RIVER_MODEL_TYPE,
     DOMAIN,
     FORECAST_TYPE_HISTORICAL_SHIFT,
+    FORECAST_TYPE_RIVER_ML,
+    RIVER_MODEL_LINEAR,
+    RIVER_MODEL_SNARIMAX,
 )
 
 
@@ -22,6 +31,10 @@ class HafoConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Home Assistant Forecaster."""
 
     VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._data: dict[str, Any] = {}
 
     @staticmethod
     @callback
@@ -33,30 +46,73 @@ class HafoConfigFlow(ConfigFlow, domain=DOMAIN):
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
+        """Handle the initial step - select forecast type."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # Validate the source entity exists
+            self._data.update(user_input)
+            forecast_type = user_input.get(CONF_FORECAST_TYPE, DEFAULT_FORECAST_TYPE)
+
+            if forecast_type == FORECAST_TYPE_RIVER_ML:
+                return await self.async_step_river_ml()
+            return await self.async_step_historical_shift()
+
+        # Build the schema for forecast type selection
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_FORECAST_TYPE,
+                    default=DEFAULT_FORECAST_TYPE,
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(
+                                value=FORECAST_TYPE_HISTORICAL_SHIFT,
+                                label="Historical Shift",
+                            ),
+                            selector.SelectOptionDict(
+                                value=FORECAST_TYPE_RIVER_ML,
+                                label="RiverML",
+                            ),
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_historical_shift(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle Historical Shift configuration."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
             source_entity = user_input[CONF_SOURCE_ENTITY]
             if self.hass.states.get(source_entity) is None:
                 errors[CONF_SOURCE_ENTITY] = "entity_not_found"
             else:
-                # Create unique ID from source entity
+                self._data.update(user_input)
+
                 await self.async_set_unique_id(f"{DOMAIN}_{source_entity}")
                 self._abort_if_unique_id_configured()
 
-                # Create a friendly title from the source entity
                 state = self.hass.states.get(source_entity)
                 friendly_name = state.attributes.get("friendly_name", source_entity) if state else source_entity
                 title = f"{friendly_name} Forecast"
 
                 return self.async_create_entry(
                     title=title,
-                    data=user_input,
+                    data=self._data,
                 )
 
-        # Build the schema for user input
         schema = vol.Schema(
             {
                 vol.Required(CONF_SOURCE_ENTITY): selector.EntitySelector(
@@ -74,15 +130,107 @@ class HafoConfigFlow(ConfigFlow, domain=DOMAIN):
                         unit_of_measurement="days",
                     )
                 ),
+            }
+        )
+
+        return self.async_show_form(
+            step_id="historical_shift",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_river_ml(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Handle RiverML configuration."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            input_entities = user_input.get(CONF_INPUT_ENTITIES, [])
+            output_entity = user_input.get(CONF_OUTPUT_ENTITY)
+
+            # Validate at least one input entity
+            if not input_entities:
+                errors[CONF_INPUT_ENTITIES] = "no_input_entities"
+            # Validate output entity exists
+            elif output_entity and self.hass.states.get(output_entity) is None:
+                errors[CONF_OUTPUT_ENTITY] = "entity_not_found"
+            # Validate output is not in inputs
+            elif output_entity in input_entities:
+                errors[CONF_OUTPUT_ENTITY] = "output_in_inputs"
+            # Validate all input entities exist
+            else:
+                for entity_id in input_entities:
+                    if self.hass.states.get(entity_id) is None:
+                        errors[CONF_INPUT_ENTITIES] = "entity_not_found"
+                        break
+
+            if not errors:
+                # output_entity is validated above
+                output_entity = cast("str", output_entity)
+                self._data.update(user_input)
+
+                await self.async_set_unique_id(f"{DOMAIN}_{output_entity}")
+                self._abort_if_unique_id_configured()
+
+                state = self.hass.states.get(output_entity)
+                friendly_name = state.attributes.get("friendly_name", output_entity) if state else output_entity
+                title = f"{friendly_name} RiverML Forecast"
+
+                return self.async_create_entry(
+                    title=title,
+                    data=self._data,
+                )
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_INPUT_ENTITIES): selector.EntitySelector(
+                    selector.EntitySelectorConfig(
+                        domain=["sensor", "input_number"],
+                        multiple=True,
+                    )
+                ),
+                vol.Required(CONF_OUTPUT_ENTITY): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=["sensor", "input_number"])
+                ),
                 vol.Optional(
-                    CONF_FORECAST_TYPE,
-                    default=DEFAULT_FORECAST_TYPE,
+                    CONF_HISTORY_DAYS,
+                    default=DEFAULT_HISTORY_DAYS,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1,
+                        max=30,
+                        step=1,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="days",
+                    )
+                ),
+                vol.Optional(
+                    CONF_FORECAST_HOURS,
+                    default=DEFAULT_FORECAST_HOURS,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1,
+                        max=720,  # 30 days
+                        step=1,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="hours",
+                    )
+                ),
+                vol.Optional(
+                    CONF_RIVER_MODEL_TYPE,
+                    default=DEFAULT_RIVER_MODEL_TYPE,
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=[
                             selector.SelectOptionDict(
-                                value=FORECAST_TYPE_HISTORICAL_SHIFT,
-                                label="Historical Shift",
+                                value=RIVER_MODEL_SNARIMAX,
+                                label="SNARIMAX",
+                            ),
+                            selector.SelectOptionDict(
+                                value=RIVER_MODEL_LINEAR,
+                                label="Linear Regression",
                             ),
                         ],
                         mode=selector.SelectSelectorMode.DROPDOWN,
@@ -92,7 +240,7 @@ class HafoConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(
-            step_id="user",
+            step_id="river_ml",
             data_schema=schema,
             errors=errors,
         )
@@ -106,32 +254,81 @@ class HafoOptionsFlow(OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Handle options flow."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        # Get current config
         entry = self.hass.config_entries.async_get_entry(self.handler)  # type: ignore[arg-type]
         if entry is None:
             return self.async_abort(reason="entry_not_found")
 
-        current_data = entry.data
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
 
-        schema = vol.Schema(
-            {
-                vol.Optional(
-                    CONF_HISTORY_DAYS,
-                    default=current_data.get(CONF_HISTORY_DAYS, DEFAULT_HISTORY_DAYS),
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=1,
-                        max=30,
-                        step=1,
-                        mode=selector.NumberSelectorMode.BOX,
-                        unit_of_measurement="days",
-                    )
-                ),
-            }
-        )
+        current_data = entry.data
+        forecast_type = current_data.get(CONF_FORECAST_TYPE, DEFAULT_FORECAST_TYPE)
+
+        # Build schema based on forecast type
+        if forecast_type == FORECAST_TYPE_RIVER_ML:
+            schema = vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_HISTORY_DAYS,
+                        default=current_data.get(CONF_HISTORY_DAYS, DEFAULT_HISTORY_DAYS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1,
+                            max=30,
+                            step=1,
+                            mode=selector.NumberSelectorMode.BOX,
+                            unit_of_measurement="days",
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_FORECAST_HOURS,
+                        default=current_data.get(CONF_FORECAST_HOURS, DEFAULT_FORECAST_HOURS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1,
+                            max=720,
+                            step=1,
+                            mode=selector.NumberSelectorMode.BOX,
+                            unit_of_measurement="hours",
+                        )
+                    ),
+                    vol.Optional(
+                        CONF_RIVER_MODEL_TYPE,
+                        default=current_data.get(CONF_RIVER_MODEL_TYPE, DEFAULT_RIVER_MODEL_TYPE),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                selector.SelectOptionDict(
+                                    value=RIVER_MODEL_SNARIMAX,
+                                    label="SNARIMAX",
+                                ),
+                                selector.SelectOptionDict(
+                                    value=RIVER_MODEL_LINEAR,
+                                    label="Linear Regression",
+                                ),
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_HISTORY_DAYS,
+                        default=current_data.get(CONF_HISTORY_DAYS, DEFAULT_HISTORY_DAYS),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1,
+                            max=30,
+                            step=1,
+                            mode=selector.NumberSelectorMode.BOX,
+                            unit_of_measurement="days",
+                        )
+                    ),
+                }
+            )
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/hafo/config_flow.py
+++ b/custom_components/hafo/config_flow.py
@@ -156,9 +156,6 @@ class HafoConfigFlow(ConfigFlow, domain=DOMAIN):
             # Validate output entity exists
             elif output_entity and self.hass.states.get(output_entity) is None:
                 errors[CONF_OUTPUT_ENTITY] = "entity_not_found"
-            # Validate output is not in inputs
-            elif output_entity in input_entities:
-                errors[CONF_OUTPUT_ENTITY] = "output_in_inputs"
             # Validate all input entities exist
             else:
                 for entity_id in input_entities:

--- a/custom_components/hafo/const.py
+++ b/custom_components/hafo/const.py
@@ -8,16 +8,28 @@ DOMAIN: Final = "hafo"
 CONF_SOURCE_ENTITY: Final = "source_entity"
 CONF_HISTORY_DAYS: Final = "history_days"
 CONF_FORECAST_TYPE: Final = "forecast_type"
+CONF_INPUT_ENTITIES: Final = "input_entities"
+CONF_OUTPUT_ENTITY: Final = "output_entity"
+CONF_RIVER_MODEL_TYPE: Final = "river_model_type"
+CONF_FORECAST_HOURS: Final = "forecast_hours"
 
 # Forecast types
 FORECAST_TYPE_HISTORICAL_SHIFT: Final = "historical_shift"
+FORECAST_TYPE_RIVER_ML: Final = "river_ml"
+
+# RiverML model types
+RIVER_MODEL_SNARIMAX: Final = "snarimax"
+RIVER_MODEL_LINEAR: Final = "linear"
 
 # Default values
 DEFAULT_HISTORY_DAYS: Final = 7
 DEFAULT_FORECAST_TYPE: Final = FORECAST_TYPE_HISTORICAL_SHIFT
+DEFAULT_FORECAST_HOURS: Final = 168  # 7 days at hourly cadence
+DEFAULT_RIVER_MODEL_TYPE: Final = RIVER_MODEL_SNARIMAX
 
 # Attribute keys
 ATTR_FORECAST: Final = "forecast"
 ATTR_LAST_UPDATED: Final = "last_forecast_update"
 ATTR_SOURCE_ENTITY: Final = "source_entity"
 ATTR_HISTORY_DAYS: Final = "history_days"
+ATTR_MODEL_METRICS: Final = "model_metrics"

--- a/custom_components/hafo/coordinator.py
+++ b/custom_components/hafo/coordinator.py
@@ -7,15 +7,17 @@ coordinator based on the forecast type configured in the entry.
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_FORECAST_TYPE, FORECAST_TYPE_HISTORICAL_SHIFT
+from .const import CONF_FORECAST_TYPE, FORECAST_TYPE_HISTORICAL_SHIFT, FORECAST_TYPE_RIVER_ML
 from .forecasters.historical_shift import ForecastResult, HistoricalShiftForecaster
+from .forecasters.river_ml import RiverMLForecaster
 
 # Type alias for any forecaster coordinator
-type ForecasterCoordinator = HistoricalShiftForecaster
+type ForecasterCoordinator = HistoricalShiftForecaster | RiverMLForecaster
 
 # Mapping of forecast types to their coordinator classes
 FORECASTER_TYPES: dict[str, type[ForecasterCoordinator]] = {
     FORECAST_TYPE_HISTORICAL_SHIFT: HistoricalShiftForecaster,
+    FORECAST_TYPE_RIVER_ML: RiverMLForecaster,
 }
 
 

--- a/custom_components/hafo/forecasters/__init__.py
+++ b/custom_components/hafo/forecasters/__init__.py
@@ -1,5 +1,13 @@
 """Forecasters package for Home Assistant Forecaster."""
 
-from .historical_shift import ForecastPoint, ForecastResult, HistoricalShiftForecaster
+from .common import ForecastPoint, ForecastResult, StatisticsLike, get_statistics_for_sensor, get_statistics_for_sensors
+from .historical_shift import HistoricalShiftForecaster
 
-__all__ = ["ForecastPoint", "ForecastResult", "HistoricalShiftForecaster"]
+__all__ = [
+    "ForecastPoint",
+    "ForecastResult",
+    "HistoricalShiftForecaster",
+    "StatisticsLike",
+    "get_statistics_for_sensor",
+    "get_statistics_for_sensors",
+]

--- a/custom_components/hafo/forecasters/common/__init__.py
+++ b/custom_components/hafo/forecasters/common/__init__.py
@@ -1,0 +1,12 @@
+"""Common utilities for HAFO forecasters."""
+
+from .statistics import get_statistics_for_sensor, get_statistics_for_sensors
+from .types import ForecastPoint, ForecastResult, StatisticsLike
+
+__all__ = [
+    "ForecastPoint",
+    "ForecastResult",
+    "StatisticsLike",
+    "get_statistics_for_sensor",
+    "get_statistics_for_sensors",
+]

--- a/custom_components/hafo/forecasters/common/statistics.py
+++ b/custom_components/hafo/forecasters/common/statistics.py
@@ -1,0 +1,102 @@
+"""Statistics utilities for fetching historical data from the recorder."""
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any, Literal
+
+from homeassistant.core import HomeAssistant
+
+# Type alias for statistics rows - accepts various dict-like structures
+type StatisticsRowLike = Mapping[str, Any]
+
+# Type aliases for statistics API
+type StatisticPeriod = Literal["5minute", "hour", "day", "week", "month"]
+type StatisticType = Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]
+
+
+async def get_statistics_for_sensor(
+    hass: HomeAssistant,
+    entity_id: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> Sequence[StatisticsRowLike]:
+    """Fetch hourly statistics for a sensor entity.
+
+    Args:
+        hass: Home Assistant instance
+        entity_id: The sensor entity ID to fetch statistics for
+        start_time: Start of the time range
+        end_time: End of the time range
+
+    Returns:
+        List of statistics rows with 'start' and 'mean' fields.
+
+    Raises:
+        ValueError: If the recorder is not available or not set up.
+
+    """
+    result = await get_statistics_for_sensors(hass, {entity_id}, start_time, end_time)
+    return result.get(entity_id, [])
+
+
+async def get_statistics_for_sensors(
+    hass: HomeAssistant,
+    entity_ids: set[str],
+    start_time: datetime,
+    end_time: datetime,
+    *,
+    period: StatisticPeriod = "hour",
+    types: set[StatisticType] | None = None,
+) -> Mapping[str, Sequence[StatisticsRowLike]]:
+    """Fetch statistics for multiple sensor entities.
+
+    Args:
+        hass: Home Assistant instance
+        entity_ids: Set of sensor entity IDs to fetch statistics for
+        start_time: Start of the time range
+        end_time: End of the time range
+        period: Statistics period ('5minute', 'hour', 'day', 'week', 'month')
+        types: Set of statistics types to fetch (default: {'mean'})
+
+    Returns:
+        Dictionary mapping entity IDs to their statistics rows.
+
+    Raises:
+        ValueError: If the recorder is not available or not set up.
+
+    """
+    stat_types: set[StatisticType] = types if types is not None else {"mean"}
+
+    if "recorder" not in hass.config.components:
+        msg = "Recorder component not loaded"
+        raise ValueError(msg)
+
+    try:
+        # Recorder is an optional after_dependency, so we import inline after checking it's loaded
+        from homeassistant.components.recorder.statistics import statistics_during_period  # noqa: PLC0415
+        from homeassistant.helpers.recorder import DATA_INSTANCE  # noqa: PLC0415
+
+        if DATA_INSTANCE not in hass.data:
+            msg = "Recorder not initialized"
+            raise ValueError(msg)
+    except ImportError:
+        msg = "Recorder component not available"
+        raise ValueError(msg) from None
+
+    try:
+        statistics = await hass.async_add_executor_job(
+            lambda: statistics_during_period(
+                hass,
+                start_time,
+                end_time,
+                entity_ids,
+                period,
+                None,
+                stat_types,
+            )
+        )
+    except Exception as e:
+        msg = f"Failed to fetch statistics: {e}"
+        raise ValueError(msg) from e
+
+    return statistics

--- a/custom_components/hafo/forecasters/common/types.py
+++ b/custom_components/hafo/forecasters/common/types.py
@@ -1,0 +1,28 @@
+"""Common types for HAFO forecasters."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+# Type alias for statistics - accepts either StatisticsRow or dict-like objects
+type StatisticsLike = Mapping[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastPoint:
+    """A single point in a forecast time series."""
+
+    time: datetime
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastResult:
+    """Result of a forecast operation."""
+
+    forecast: list[ForecastPoint]
+    source_entity: str
+    history_days: int
+    generated_at: datetime
+    metrics: dict[str, float] = field(default_factory=dict)

--- a/custom_components/hafo/forecasters/river_ml.py
+++ b/custom_components/hafo/forecasters/river_ml.py
@@ -1,0 +1,540 @@
+"""RiverML forecaster.
+
+This forecaster uses River's online machine learning capabilities for multi-variate
+time series forecasting. It supports multiple input entities as features to predict
+a single output entity, with incremental learning from new data.
+"""
+
+from collections.abc import Mapping, Sequence
+import contextlib
+from datetime import datetime, timedelta
+import logging
+from pathlib import Path
+import pickle
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+from river import linear_model, metrics, preprocessing, time_series
+
+from custom_components.hafo.const import (
+    CONF_FORECAST_HOURS,
+    CONF_HISTORY_DAYS,
+    CONF_INPUT_ENTITIES,
+    CONF_OUTPUT_ENTITY,
+    CONF_RIVER_MODEL_TYPE,
+    DEFAULT_FORECAST_HOURS,
+    DEFAULT_HISTORY_DAYS,
+    DEFAULT_RIVER_MODEL_TYPE,
+    DOMAIN,
+    RIVER_MODEL_SNARIMAX,
+)
+
+from .common import ForecastPoint, ForecastResult, get_statistics_for_sensors
+
+_LOGGER = logging.getLogger(__name__)
+
+# Storage directory for model persistence
+STORAGE_DIR = ".storage/hafo_models"
+
+# Type alias for RiverML models (SNARIMAX, Pipeline, etc.)
+type RiverModel = Any
+
+
+class RiverMLForecaster(DataUpdateCoordinator[ForecastResult | None]):
+    """Forecaster using River's online machine learning for multi-variate prediction.
+
+    This forecaster uses multiple input entities as features to predict a single
+    output entity. It supports incremental learning, keeping the model in memory
+    and persisting to disk after updates.
+
+    Update interval: Hourly, aligned with recorder hourly statistics.
+    """
+
+    UPDATE_INTERVAL = timedelta(hours=1)
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the forecaster.
+
+        Args:
+            hass: Home Assistant instance
+            entry: Config entry containing forecaster settings
+
+        """
+        self._entry = entry
+        self._input_entities: list[str] = list(entry.data[CONF_INPUT_ENTITIES])
+        self._output_entity: str = entry.data[CONF_OUTPUT_ENTITY]
+        self._history_days: int = int(entry.data.get(CONF_HISTORY_DAYS, DEFAULT_HISTORY_DAYS))
+        self._forecast_hours: int = int(entry.data.get(CONF_FORECAST_HOURS, DEFAULT_FORECAST_HOURS))
+        self._model_type: str = entry.data.get(CONF_RIVER_MODEL_TYPE, DEFAULT_RIVER_MODEL_TYPE)
+
+        # Model state (kept in memory)
+        self._model: RiverModel | None = None
+        self._last_update_timestamp: datetime | None = None
+        self._metrics = metrics.MAE() + metrics.RMSE()
+        self._metrics_samples: int = 0
+
+        # Last known values for input entities (for future forecasting)
+        self._last_known_inputs: dict[str, float] = {}
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_{entry.entry_id}",
+            update_interval=self.UPDATE_INTERVAL,
+            config_entry=entry,
+        )
+
+        # Load persisted model on initialization
+        self._load_model_from_disk()
+
+    @property
+    def source_entity(self) -> str:
+        """Return the primary source entity (output entity for RiverML)."""
+        return self._output_entity
+
+    @property
+    def history_days(self) -> int:
+        """Return the number of history days used for initial training."""
+        return self._history_days
+
+    @property
+    def entry(self) -> ConfigEntry:
+        """Return the config entry."""
+        return self._entry
+
+    @property
+    def forecast_hours(self) -> int:
+        """Return the forecast horizon in hours."""
+        return self._forecast_hours
+
+    @property
+    def input_entities(self) -> list[str]:
+        """Return the list of input entities."""
+        return self._input_entities
+
+    @property
+    def output_entity(self) -> str:
+        """Return the output entity."""
+        return self._output_entity
+
+    @property
+    def model_type(self) -> str:
+        """Return the model type."""
+        return self._model_type
+
+    def _get_storage_path(self) -> Path:
+        """Get the path for model persistence."""
+        return Path(self.hass.config.path(STORAGE_DIR)) / f"{self._entry.entry_id}.pkl"
+
+    def _load_model_from_disk(self) -> None:
+        """Load persisted model from disk if available."""
+        storage_path = self._get_storage_path()
+
+        if not storage_path.exists():
+            _LOGGER.debug("No persisted model found at %s", storage_path)
+            return
+
+        try:
+            with storage_path.open("rb") as f:
+                data = pickle.load(f)  # noqa: S301
+
+            self._model = data.get("model")
+            self._last_update_timestamp = data.get("last_update_timestamp")
+            self._last_known_inputs = data.get("last_known_inputs", {})
+            metrics_data = data.get("metrics")
+            if metrics_data:
+                self._metrics = metrics_data
+            self._metrics_samples = data.get("metrics_samples", 0)
+
+            _LOGGER.debug(
+                "Loaded model from disk, last update: %s",
+                self._last_update_timestamp,
+            )
+        except Exception as e:
+            _LOGGER.warning("Failed to load model from disk: %s, will train from scratch", e)
+            self._model = None
+            self._last_update_timestamp = None
+
+    def _save_model_to_disk(self) -> None:
+        """Save model state to disk."""
+        storage_path = self._get_storage_path()
+
+        # Ensure directory exists
+        storage_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "model": self._model,
+            "last_update_timestamp": self._last_update_timestamp,
+            "last_known_inputs": self._last_known_inputs,
+            "metrics": self._metrics,
+            "metrics_samples": self._metrics_samples,
+        }
+
+        try:
+            with storage_path.open("wb") as f:
+                pickle.dump(data, f)
+            _LOGGER.debug("Saved model to disk at %s", storage_path)
+        except Exception as e:
+            _LOGGER.warning("Failed to save model to disk: %s", e)
+
+    def _create_model(self) -> RiverModel:
+        """Create a new model based on configured type."""
+        if self._model_type == RIVER_MODEL_SNARIMAX:
+            # SNARIMAX with sensible defaults for hourly data
+            # p=24 for daily patterns, m=24 for daily seasonality
+            return time_series.SNARIMAX(
+                p=24,  # Autoregressive order (past 24 hours)
+                d=0,  # Differencing order
+                q=0,  # Moving average order
+                m=24,  # Seasonal period (daily)
+                sp=1,  # Seasonal autoregressive order
+                sd=0,  # Seasonal differencing order
+                sq=0,  # Seasonal moving average order
+            )
+
+        # Linear regression with standard scaler pipeline
+        return preprocessing.StandardScaler() | linear_model.LinearRegression()
+
+    async def _available(self) -> bool:
+        """Check if we can generate a forecast.
+
+        Returns:
+            True if the recorder component is available and all entities exist.
+
+        """
+        if "recorder" not in self.hass.config.components:
+            return False
+
+        # Check all input entities exist
+        for entity_id in self._input_entities:
+            if self.hass.states.get(entity_id) is None:
+                return False
+
+        # Check output entity exists
+        return self.hass.states.get(self._output_entity) is not None
+
+    async def _async_update_data(self) -> ForecastResult | None:
+        """Fetch and update forecast data.
+
+        Returns:
+            ForecastResult with the latest forecast, or None if unavailable.
+
+        Raises:
+            UpdateFailed: If the forecast cannot be generated.
+
+        """
+        try:
+            if not await self._available():
+                _LOGGER.warning("Forecaster not available - recorder may not be ready or entities missing")
+                return None
+
+            # Train or update the model
+            await self._train_or_update_model()
+
+            # Generate forecast
+            result = await self._generate_forecast()
+
+            _LOGGER.debug(
+                "Generated forecast for %s with %d points",
+                self._output_entity,
+                len(result.forecast),
+            )
+
+            return result
+
+        except ValueError as err:
+            _LOGGER.warning("Failed to generate forecast: %s", err)
+            return None
+        except Exception as err:
+            msg = f"Error generating forecast: {err}"
+            raise UpdateFailed(msg) from err
+
+    async def _train_or_update_model(self) -> None:
+        """Train a new model or update existing model with new data."""
+        now = dt_util.now()
+
+        if self._model is None:
+            # First run: train on full historical dataset
+            _LOGGER.debug("No model in memory, training from scratch")
+            await self._train_from_scratch(now)
+        else:
+            # Incremental update with new data
+            await self._incremental_update(now)
+
+        # Save model to disk after update
+        await self.hass.async_add_executor_job(self._save_model_to_disk)
+
+    async def _train_from_scratch(self, now: datetime) -> None:
+        """Train a new model on full historical dataset."""
+        start_time = now - timedelta(days=self._history_days)
+        end_time = now
+
+        # Fetch statistics for all entities
+        all_entities = set(self._input_entities) | {self._output_entity}
+        statistics = await get_statistics_for_sensors(
+            self.hass,
+            all_entities,
+            start_time,
+            end_time,
+        )
+
+        # Align data across entities
+        aligned_data = self._align_statistics(statistics)
+
+        if not aligned_data:
+            msg = "No aligned historical data available for training"
+            raise ValueError(msg)
+
+        # Create and train model
+        self._model = self._create_model()
+
+        for _, features, target in aligned_data:
+            self._train_one(features, target)
+            # Update last known inputs
+            self._last_known_inputs = features.copy()
+
+        self._last_update_timestamp = now
+        _LOGGER.info(
+            "Trained model on %d data points for %s",
+            len(aligned_data),
+            self._output_entity,
+        )
+
+    async def _incremental_update(self, now: datetime) -> None:
+        """Update model incrementally with new data since last update."""
+        if self._last_update_timestamp is None:
+            # Should not happen, but fallback to training from scratch
+            await self._train_from_scratch(now)
+            return
+
+        start_time = self._last_update_timestamp
+        end_time = now
+
+        # Skip if no new data expected
+        if end_time - start_time < self.UPDATE_INTERVAL:
+            _LOGGER.debug("Less than update interval since last update, skipping")
+            return
+
+        # Fetch statistics for all entities
+        all_entities = set(self._input_entities) | {self._output_entity}
+        statistics = await get_statistics_for_sensors(
+            self.hass,
+            all_entities,
+            start_time,
+            end_time,
+        )
+
+        # Align data across entities
+        aligned_data = self._align_statistics(statistics)
+
+        if not aligned_data:
+            _LOGGER.debug("No new aligned data for incremental update")
+            self._last_update_timestamp = now
+            return
+
+        # Update model incrementally
+        for _, features, target in aligned_data:
+            # Update metrics with prediction before learning
+            if self._model is not None:
+                prediction = self._predict_one(features)
+                if prediction is not None:
+                    self._metrics.update(target, prediction)
+                    self._metrics_samples += 1
+
+            self._train_one(features, target)
+            # Update last known inputs
+            self._last_known_inputs = features.copy()
+
+        self._last_update_timestamp = now
+        _LOGGER.debug(
+            "Incremental update with %d data points",
+            len(aligned_data),
+        )
+
+    def _align_statistics(
+        self,
+        statistics: Mapping[str, Sequence[Mapping[str, Any]]],
+    ) -> list[tuple[datetime, dict[str, float], float]]:
+        """Align statistics across multiple entities by timestamp.
+
+        Returns list of (timestamp, features_dict, target_value) tuples
+        where all entities have data.
+        """
+        # Build timestamp -> values mapping for each entity
+        entity_data: dict[str, dict[datetime, float]] = {}
+
+        for entity_id, stats in statistics.items():
+            entity_data[entity_id] = {}
+            for stat in stats:
+                start = stat.get("start")
+                mean = stat.get("mean")
+
+                if start is None or mean is None:
+                    continue
+
+                if isinstance(start, datetime):
+                    dt_start = start
+                else:
+                    try:
+                        timestamp = float(start)
+                        dt_start = datetime.fromtimestamp(timestamp, tz=dt_util.get_default_time_zone())
+                    except (TypeError, ValueError):
+                        continue
+
+                entity_data[entity_id][dt_start] = float(mean)
+
+        # Find common timestamps where all entities have data
+        if not entity_data:
+            return []
+
+        common_timestamps = set.intersection(*(set(data.keys()) for data in entity_data.values()))
+
+        if not common_timestamps:
+            return []
+
+        # Build aligned data
+        aligned: list[tuple[datetime, dict[str, float], float]] = []
+        for timestamp in sorted(common_timestamps):
+            features = {entity_id: entity_data[entity_id][timestamp] for entity_id in self._input_entities}
+            target = entity_data[self._output_entity][timestamp]
+            aligned.append((timestamp, features, target))
+
+        return aligned
+
+    def _train_one(self, features: dict[str, float], target: float) -> None:
+        """Train the model on a single data point."""
+        if self._model is None:
+            return
+
+        if self._model_type == RIVER_MODEL_SNARIMAX:
+            # SNARIMAX uses x for exogenous variables
+            self._model.learn_one(y=target, x=features)
+        else:
+            # Linear regression uses x for features
+            self._model.learn_one(x=features, y=target)
+
+    def _predict_one(self, features: dict[str, float]) -> float | None:
+        """Predict a single value given features."""
+        if self._model is None:
+            return None
+
+        try:
+            if self._model_type == RIVER_MODEL_SNARIMAX:
+                # SNARIMAX forecast_one with exogenous variables
+                return self._model.forecast(horizon=1, xs=[features])[0]
+            # Linear regression predict_one
+            return self._model.predict_one(x=features)
+        except Exception as e:
+            _LOGGER.debug("Prediction failed: %s", e)
+            return None
+
+    def _get_future_input_values(
+        self,
+        entity_id: str,
+        future_times: list[datetime],
+    ) -> list[float]:
+        """Get input values for future timestamps.
+
+        This is an extension point for future forecast consumption.
+        Currently returns last known value for all future steps.
+
+        Args:
+            entity_id: The input entity ID
+            future_times: List of future timestamps to get values for
+
+        Returns:
+            List of values for each future timestamp
+
+        """
+        # EXTENSION POINT: Future implementation can check for external forecasts
+        # from the entity's forecast attribute here. For now, use last known value.
+        last_value = self._last_known_inputs.get(entity_id, 0.0)
+        return [last_value] * len(future_times)
+
+    async def _generate_forecast(self) -> ForecastResult:
+        """Generate forecast using the trained model.
+
+        Returns:
+            ForecastResult with the generated forecast.
+
+        Raises:
+            ValueError: If no model is available.
+
+        """
+        if self._model is None:
+            msg = "No model available for forecasting"
+            raise ValueError(msg)
+
+        now = dt_util.now()
+
+        # Generate future timestamps at hourly intervals
+        future_times = [now + timedelta(hours=i) for i in range(1, self._forecast_hours + 1)]
+
+        # Get future input values for all input entities
+        future_inputs: dict[str, list[float]] = {}
+        for entity_id in self._input_entities:
+            future_inputs[entity_id] = self._get_future_input_values(entity_id, future_times)
+
+        # Generate predictions
+        forecast_points: list[ForecastPoint] = []
+
+        if self._model_type == RIVER_MODEL_SNARIMAX:
+            # SNARIMAX can forecast multiple steps at once with exogenous variables
+            xs = [
+                {entity_id: future_inputs[entity_id][i] for entity_id in self._input_entities}
+                for i in range(len(future_times))
+            ]
+            try:
+                predictions = self._model.forecast(horizon=len(future_times), xs=xs)
+                for i, prediction in enumerate(predictions):
+                    forecast_points.append(ForecastPoint(time=future_times[i], value=float(prediction)))
+            except Exception as e:
+                _LOGGER.warning("SNARIMAX forecast failed: %s", e)
+                msg = f"Failed to generate forecast: {e}"
+                raise ValueError(msg) from e
+        else:
+            # Linear regression: predict one step at a time
+            for i, future_time in enumerate(future_times):
+                features = {entity_id: future_inputs[entity_id][i] for entity_id in self._input_entities}
+                prediction = self._predict_one(features)
+                if prediction is not None:
+                    forecast_points.append(ForecastPoint(time=future_time, value=prediction))
+
+        if not forecast_points:
+            msg = "No valid forecast points generated"
+            raise ValueError(msg)
+
+        # Build metrics dict
+        model_metrics = self._get_metrics()
+
+        return ForecastResult(
+            forecast=forecast_points,
+            source_entity=self._output_entity,
+            history_days=self._history_days,
+            generated_at=now,
+            metrics=model_metrics,
+        )
+
+    def _get_metrics(self) -> dict[str, float]:
+        """Get current model performance metrics."""
+        if self._metrics_samples == 0:
+            return {}
+
+        result: dict[str, float] = {"samples": float(self._metrics_samples)}
+
+        # Extract individual metrics from composite
+        for metric in self._metrics:
+            metric_name = metric.__class__.__name__.lower()
+            with contextlib.suppress(Exception):
+                result[metric_name] = float(metric.get())
+
+        return result
+
+    def cleanup(self) -> None:
+        """Clean up coordinator resources."""
+        _LOGGER.debug("Cleaning up RiverML forecaster for %s", self._output_entity)
+        # Save model one last time before cleanup
+        self._save_model_to_disk()

--- a/custom_components/hafo/manifest.json
+++ b/custom_components/hafo/manifest.json
@@ -9,6 +9,6 @@
   "integration_type": "helper",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/hass-energy/hafo/issues",
-  "requirements": [],
+  "requirements": ["river>=0.23.0"],
   "version": "0.1.0"
 }

--- a/custom_components/hafo/translations/en.json
+++ b/custom_components/hafo/translations/en.json
@@ -3,17 +3,46 @@
     "flow_title": "{name}",
     "step": {
       "user": {
-        "title": "Create Forecast Helper",
-        "description": "Create a forecast sensor that shifts historical data forward to predict future values.",
-        "data": { "forecast_type": "Forecast type", "history_days": "History days", "source_entity": "Source entity" },
+        "title": "Select Forecast Type",
+        "description": "Choose the forecasting algorithm to use for generating predictions.",
+        "data": { "forecast_type": "Forecast type" },
         "data_description": {
-          "forecast_type": "The forecasting algorithm to use",
+          "forecast_type": "Historical Shift uses past data shifted forward. RiverML uses machine learning with multiple input entities."
+        }
+      },
+      "historical_shift": {
+        "title": "Configure Historical Shift Forecast",
+        "description": "Create a forecast sensor that shifts historical data forward to predict future values.",
+        "data": { "history_days": "History days", "source_entity": "Source entity" },
+        "data_description": {
           "history_days": "Number of days of history to fetch and shift forward (1-30)",
           "source_entity": "The sensor entity to generate a forecast for"
         }
+      },
+      "river_ml": {
+        "title": "Configure RiverML Forecast",
+        "description": "Create a forecast sensor using machine learning with multiple input entities to predict output values.",
+        "data": {
+          "forecast_hours": "Forecast hours",
+          "history_days": "History days",
+          "input_entities": "Input entities",
+          "output_entity": "Output entity",
+          "river_model_type": "Model type"
+        },
+        "data_description": {
+          "forecast_hours": "Number of hours to forecast into the future (1-720)",
+          "history_days": "Number of days of historical data for initial training (1-30)",
+          "input_entities": "Entities to use as input features for prediction",
+          "output_entity": "The entity to predict (target)",
+          "river_model_type": "SNARIMAX handles seasonal patterns with exogenous variables. Linear Regression is a simpler baseline."
+        }
       }
     },
-    "error": { "entity_not_found": "The selected entity was not found" },
+    "error": {
+      "entity_not_found": "The selected entity was not found",
+      "no_input_entities": "At least one input entity is required",
+      "output_in_inputs": "Output entity cannot be one of the input entities"
+    },
     "abort": { "already_configured": "A forecast helper for this entity already exists" }
   },
   "options": {
@@ -21,8 +50,16 @@
       "init": {
         "title": "Configure Forecast Helper",
         "description": "Adjust the forecast settings",
-        "data": { "history_days": "History days" },
-        "data_description": { "history_days": "Number of days of history to fetch and shift forward (1-30)" }
+        "data": {
+          "forecast_hours": "Forecast hours",
+          "history_days": "History days",
+          "river_model_type": "Model type"
+        },
+        "data_description": {
+          "forecast_hours": "Number of hours to forecast into the future (1-720)",
+          "history_days": "Number of days of history to fetch and shift forward (1-30)",
+          "river_model_type": "SNARIMAX handles seasonal patterns with exogenous variables. Linear Regression is a simpler baseline."
+        }
       }
     }
   },

--- a/custom_components/hafo/translations/en.json
+++ b/custom_components/hafo/translations/en.json
@@ -40,8 +40,7 @@
     },
     "error": {
       "entity_not_found": "The selected entity was not found",
-      "no_input_entities": "At least one input entity is required",
-      "output_in_inputs": "Output entity cannot be one of the input entities"
+      "no_input_entities": "At least one input entity is required"
     },
     "abort": { "already_configured": "A forecast helper for this entity already exists" }
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Home Assistant Forecaster - Entity forecasting for Home Assistant
 readme = "README.md"
 requires-python = ">=3.13.2,<3.14"
 
-dependencies = ["homeassistant>=2025.12.2", "river>=0.22.0"]
+dependencies = ["homeassistant>=2025.12.2", "river>=0.23.0"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Home Assistant Forecaster - Entity forecasting for Home Assistant
 readme = "README.md"
 requires-python = ">=3.13.2,<3.14"
 
-dependencies = ["homeassistant>=2025.12.2"]
+dependencies = ["homeassistant>=2025.12.2", "river>=0.22.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/forecasters/test_river_ml.py
+++ b/tests/forecasters/test_river_ml.py
@@ -1,0 +1,493 @@
+"""Tests for the RiverML forecaster."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from river import compose, time_series
+
+from custom_components.hafo.const import (
+    CONF_FORECAST_HOURS,
+    CONF_FORECAST_TYPE,
+    CONF_HISTORY_DAYS,
+    CONF_INPUT_ENTITIES,
+    CONF_OUTPUT_ENTITY,
+    CONF_RIVER_MODEL_TYPE,
+    DOMAIN,
+    FORECAST_TYPE_RIVER_ML,
+    RIVER_MODEL_LINEAR,
+    RIVER_MODEL_SNARIMAX,
+)
+from custom_components.hafo.forecasters import river_ml as rml
+from custom_components.hafo.forecasters.river_ml import RiverMLForecaster
+
+
+def _create_mock_entry(
+    hass: HomeAssistant,
+    *,
+    input_entities: list[str] | None = None,
+    output_entity: str = "sensor.output",
+    history_days: int = 7,
+    forecast_hours: int = 24,
+    model_type: str = RIVER_MODEL_SNARIMAX,
+) -> MockConfigEntry:
+    """Create a mock config entry for RiverML testing."""
+    if input_entities is None:
+        input_entities = ["sensor.input1", "sensor.input2"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Test RiverML Forecast",
+        data={
+            CONF_INPUT_ENTITIES: input_entities,
+            CONF_OUTPUT_ENTITY: output_entity,
+            CONF_HISTORY_DAYS: history_days,
+            CONF_FORECAST_HOURS: forecast_hours,
+            CONF_RIVER_MODEL_TYPE: model_type,
+            CONF_FORECAST_TYPE: FORECAST_TYPE_RIVER_ML,
+        },
+        entry_id="test_riverml_entry_id",
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _create_mock_statistics(
+    start_time: datetime,
+    hours: int,
+    entity_values: dict[str, list[float]],
+) -> dict[str, list[dict[str, Any]]]:
+    """Create mock statistics for multiple entities."""
+    result: dict[str, list[dict[str, Any]]] = {}
+
+    for entity_id, values in entity_values.items():
+        result[entity_id] = [
+            {"start": start_time + timedelta(hours=i), "mean": values[i % len(values)]} for i in range(hours)
+        ]
+
+    return result
+
+
+# Tests for RiverMLForecaster class properties
+
+
+def test_forecaster_properties(hass: HomeAssistant) -> None:
+    """Forecaster exposes configuration properties."""
+    entry = _create_mock_entry(
+        hass,
+        input_entities=["sensor.temp", "sensor.humidity"],
+        output_entity="sensor.power",
+        history_days=14,
+        forecast_hours=48,
+        model_type=RIVER_MODEL_LINEAR,
+    )
+    forecaster = RiverMLForecaster(hass, entry)
+
+    assert forecaster.input_entities == ["sensor.temp", "sensor.humidity"]
+    assert forecaster.output_entity == "sensor.power"
+    assert forecaster.source_entity == "sensor.power"
+    assert forecaster.history_days == 14
+    assert forecaster.forecast_hours == 48
+    assert forecaster.model_type == RIVER_MODEL_LINEAR
+    assert forecaster.entry is entry
+
+
+def test_forecaster_update_interval() -> None:
+    """Forecaster has hourly update interval."""
+    assert timedelta(hours=1) == RiverMLForecaster.UPDATE_INTERVAL
+
+
+# Tests for availability
+
+
+async def test_forecaster_available_when_all_entities_exist(hass: HomeAssistant) -> None:
+    """_available() returns True when recorder is loaded and all entities exist."""
+    hass.config.components.add("recorder")
+    hass.states.async_set("sensor.input1", "10.0")
+    hass.states.async_set("sensor.input2", "20.0")
+    hass.states.async_set("sensor.output", "100.0")
+
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    assert await forecaster._available()
+
+
+async def test_forecaster_not_available_when_recorder_missing(hass: HomeAssistant) -> None:
+    """_available() returns False when recorder is not loaded."""
+    hass.states.async_set("sensor.input1", "10.0")
+    hass.states.async_set("sensor.input2", "20.0")
+    hass.states.async_set("sensor.output", "100.0")
+
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    assert not await forecaster._available()
+
+
+async def test_forecaster_not_available_when_input_entity_missing(hass: HomeAssistant) -> None:
+    """_available() returns False when an input entity doesn't exist."""
+    hass.config.components.add("recorder")
+    hass.states.async_set("sensor.input1", "10.0")
+    # sensor.input2 is missing
+    hass.states.async_set("sensor.output", "100.0")
+
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    assert not await forecaster._available()
+
+
+async def test_forecaster_not_available_when_output_entity_missing(hass: HomeAssistant) -> None:
+    """_available() returns False when output entity doesn't exist."""
+    hass.config.components.add("recorder")
+    hass.states.async_set("sensor.input1", "10.0")
+    hass.states.async_set("sensor.input2", "20.0")
+    # sensor.output is missing
+
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    assert not await forecaster._available()
+
+
+# Tests for model creation
+
+
+def test_create_snarimax_model(hass: HomeAssistant) -> None:
+    """Creates SNARIMAX model when configured."""
+    entry = _create_mock_entry(hass, model_type=RIVER_MODEL_SNARIMAX)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    model = forecaster._create_model()
+
+    assert isinstance(model, time_series.SNARIMAX)
+
+
+def test_create_linear_regression_model(hass: HomeAssistant) -> None:
+    """Creates Linear Regression pipeline when configured."""
+    entry = _create_mock_entry(hass, model_type=RIVER_MODEL_LINEAR)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    model = forecaster._create_model()
+
+    # Should be a pipeline with StandardScaler and LinearRegression
+    assert isinstance(model, compose.Pipeline)
+
+
+# Tests for data alignment
+
+
+def test_align_statistics_common_timestamps(hass: HomeAssistant) -> None:
+    """Aligns statistics across multiple entities by timestamp."""
+    entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
+    forecaster = RiverMLForecaster(hass, entry)
+
+    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+    statistics = {
+        "sensor.input1": [
+            {"start": base, "mean": 10.0},
+            {"start": base + timedelta(hours=1), "mean": 20.0},
+            {"start": base + timedelta(hours=2), "mean": 30.0},
+        ],
+        "sensor.output": [
+            {"start": base, "mean": 100.0},
+            {"start": base + timedelta(hours=1), "mean": 200.0},
+            # Missing hour 2
+        ],
+    }
+
+    aligned = forecaster._align_statistics(statistics)
+
+    # Only timestamps with all entities should be included
+    assert len(aligned) == 2
+    assert aligned[0][1] == {"sensor.input1": 10.0}
+    assert aligned[0][2] == pytest.approx(100.0)
+    assert aligned[1][1] == {"sensor.input1": 20.0}
+    assert aligned[1][2] == pytest.approx(200.0)
+
+
+def test_align_statistics_empty_when_no_common_timestamps(hass: HomeAssistant) -> None:
+    """Returns empty list when no common timestamps exist."""
+    entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
+    forecaster = RiverMLForecaster(hass, entry)
+
+    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+    statistics = {
+        "sensor.input1": [
+            {"start": base, "mean": 10.0},
+        ],
+        "sensor.output": [
+            {"start": base + timedelta(hours=1), "mean": 100.0},
+        ],
+    }
+
+    aligned = forecaster._align_statistics(statistics)
+
+    assert aligned == []
+
+
+def test_align_statistics_skips_none_values(hass: HomeAssistant) -> None:
+    """Skips entries with None start or mean values."""
+    entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
+    forecaster = RiverMLForecaster(hass, entry)
+
+    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+    statistics = {
+        "sensor.input1": [
+            {"start": base, "mean": 10.0},
+            {"start": base + timedelta(hours=1), "mean": None},  # Should skip
+        ],
+        "sensor.output": [
+            {"start": base, "mean": 100.0},
+            {"start": base + timedelta(hours=1), "mean": 200.0},
+        ],
+    }
+
+    aligned = forecaster._align_statistics(statistics)
+
+    assert len(aligned) == 1
+    assert aligned[0][1] == {"sensor.input1": 10.0}
+
+
+# Tests for model persistence
+
+
+def test_get_storage_path(hass: HomeAssistant) -> None:
+    """Returns correct storage path for model persistence."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    path = forecaster._get_storage_path()
+
+    assert path.name == f"{entry.entry_id}.pkl"
+    assert ".storage/hafo_models" in str(path)
+
+
+def test_save_and_load_model(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Model can be saved and loaded from disk."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    # Create a model
+    forecaster._model = forecaster._create_model()
+    forecaster._last_update_timestamp = datetime(2024, 1, 1, tzinfo=UTC)
+    forecaster._last_known_inputs = {"sensor.input1": 10.0}
+
+    # Mock storage path
+    storage_path = tmp_path / f"{entry.entry_id}.pkl"
+    with patch.object(forecaster, "_get_storage_path", return_value=storage_path):
+        # Save model
+        forecaster._save_model_to_disk()
+
+        assert storage_path.exists()
+
+        # Reset model state
+        forecaster._model = None
+        forecaster._last_update_timestamp = None
+        forecaster._last_known_inputs = {}
+
+        # Load model
+        forecaster._load_model_from_disk()
+
+        assert forecaster._model is not None
+        assert forecaster._last_update_timestamp == datetime(2024, 1, 1, tzinfo=UTC)
+        assert forecaster._last_known_inputs == {"sensor.input1": 10.0}
+
+
+def test_load_model_handles_missing_file(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Loading from non-existent file leaves model as None."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    storage_path = tmp_path / "nonexistent.pkl"
+    with patch.object(forecaster, "_get_storage_path", return_value=storage_path):
+        forecaster._load_model_from_disk()
+
+        assert forecaster._model is None
+
+
+def test_load_model_handles_corrupted_file(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Loading from corrupted file leaves model as None."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    storage_path = tmp_path / f"{entry.entry_id}.pkl"
+    storage_path.write_bytes(b"corrupted data")
+
+    with patch.object(forecaster, "_get_storage_path", return_value=storage_path):
+        forecaster._load_model_from_disk()
+
+        assert forecaster._model is None
+
+
+# Tests for future input values
+
+
+def test_get_future_input_values_uses_last_known(hass: HomeAssistant) -> None:
+    """Future input values use last known value."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+    forecaster._last_known_inputs = {"sensor.input1": 42.0}
+
+    future_times = [
+        datetime(2024, 1, 1, 10, tzinfo=UTC),
+        datetime(2024, 1, 1, 11, tzinfo=UTC),
+        datetime(2024, 1, 1, 12, tzinfo=UTC),
+    ]
+
+    values = forecaster._get_future_input_values("sensor.input1", future_times)
+
+    assert values == [42.0, 42.0, 42.0]
+
+
+def test_get_future_input_values_defaults_to_zero(hass: HomeAssistant) -> None:
+    """Future input values default to 0 when no last known value."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+    forecaster._last_known_inputs = {}
+
+    future_times = [datetime(2024, 1, 1, 10, tzinfo=UTC)]
+
+    values = forecaster._get_future_input_values("sensor.unknown", future_times)
+
+    assert values == [0.0]
+
+
+# Tests for training and forecast generation
+
+
+async def test_train_from_scratch_creates_model(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Training from scratch creates and trains a model."""
+    entry = _create_mock_entry(
+        hass,
+        input_entities=["sensor.input1"],
+        output_entity="sensor.output",
+        model_type=RIVER_MODEL_LINEAR,
+    )
+    forecaster = RiverMLForecaster(hass, entry)
+
+    # Mock storage path to avoid file system issues
+    storage_path = tmp_path / f"{entry.entry_id}.pkl"
+    monkeypatch.setattr(forecaster, "_get_storage_path", lambda: storage_path)
+
+    base = datetime(2024, 1, 1, 10, 0, 0, tzinfo=UTC)
+    mock_stats = {
+        "sensor.input1": [{"start": base + timedelta(hours=i), "mean": float(i * 10)} for i in range(24)],
+        "sensor.output": [{"start": base + timedelta(hours=i), "mean": float(i * 100)} for i in range(24)],
+    }
+
+    async def mock_get_stats(*args: Any, **kwargs: Any) -> dict[str, list[dict[str, Any]]]:
+        return mock_stats
+
+    monkeypatch.setattr(rml, "get_statistics_for_sensors", mock_get_stats)
+
+    now = datetime(2024, 1, 8, 10, 0, 0, tzinfo=UTC)
+    await forecaster._train_from_scratch(now)
+
+    assert forecaster._model is not None
+    assert forecaster._last_update_timestamp == now
+    assert forecaster._last_known_inputs == {"sensor.input1": 230.0}  # Last value
+
+
+async def test_generate_forecast_returns_result(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """_generate_forecast() returns a ForecastResult."""
+    entry = _create_mock_entry(
+        hass,
+        input_entities=["sensor.input1"],
+        output_entity="sensor.output",
+        forecast_hours=24,
+        model_type=RIVER_MODEL_LINEAR,
+    )
+    forecaster = RiverMLForecaster(hass, entry)
+
+    # Mock storage path
+    storage_path = tmp_path / f"{entry.entry_id}.pkl"
+    monkeypatch.setattr(forecaster, "_get_storage_path", lambda: storage_path)
+
+    # Create and pre-train model
+    forecaster._model = forecaster._create_model()
+    forecaster._last_known_inputs = {"sensor.input1": 50.0}
+
+    # Train with some data
+    for i in range(24):
+        features = {"sensor.input1": float(i * 10)}
+        target = float(i * 100)
+        forecaster._train_one(features, target)
+
+    result = await forecaster._generate_forecast()
+
+    assert result is not None
+    assert result.source_entity == "sensor.output"
+    assert result.history_days == 7
+    assert len(result.forecast) == 24  # forecast_hours
+
+
+async def test_generate_forecast_raises_when_no_model(hass: HomeAssistant) -> None:
+    """_generate_forecast() raises when no model is available."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+    forecaster._model = None
+
+    with pytest.raises(ValueError, match="No model available"):
+        await forecaster._generate_forecast()
+
+
+# Tests for metrics
+
+
+def test_get_metrics_empty_when_no_samples(hass: HomeAssistant) -> None:
+    """Returns empty dict when no metrics samples collected."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+    forecaster._metrics_samples = 0
+
+    metrics = forecaster._get_metrics()
+
+    assert metrics == {}
+
+
+def test_get_metrics_returns_values_with_samples(hass: HomeAssistant) -> None:
+    """Returns metrics dict with values when samples collected."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    # Simulate some metric updates
+    forecaster._metrics.update(100.0, 95.0)
+    forecaster._metrics.update(200.0, 190.0)
+    forecaster._metrics_samples = 2
+
+    metrics = forecaster._get_metrics()
+
+    assert "samples" in metrics
+    assert metrics["samples"] == 2.0
+    assert "mae" in metrics
+    assert "rmse" in metrics
+
+
+# Tests for cleanup
+
+
+def test_cleanup_saves_model(hass: HomeAssistant, tmp_path: Path) -> None:
+    """Cleanup saves model to disk."""
+    entry = _create_mock_entry(hass)
+    forecaster = RiverMLForecaster(hass, entry)
+
+    storage_path = tmp_path / f"{entry.entry_id}.pkl"
+    with patch.object(forecaster, "_get_storage_path", return_value=storage_path):
+        forecaster._model = forecaster._create_model()
+        forecaster.cleanup()
+
+        assert storage_path.exists()

--- a/tests/forecasters/test_river_ml.py
+++ b/tests/forecasters/test_river_ml.py
@@ -179,11 +179,11 @@ def test_create_linear_regression_model(hass: HomeAssistant) -> None:
     assert isinstance(model, compose.Pipeline)
 
 
-# Tests for data alignment
+# Tests for building training data
 
 
-def test_align_statistics_common_timestamps(hass: HomeAssistant) -> None:
-    """Aligns statistics across multiple entities by timestamp."""
+def test_build_training_data_common_timestamps(hass: HomeAssistant) -> None:
+    """Builds training data from statistics, matching by timestamp."""
     entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
     forecaster = RiverMLForecaster(hass, entry)
 
@@ -201,17 +201,17 @@ def test_align_statistics_common_timestamps(hass: HomeAssistant) -> None:
         ],
     }
 
-    aligned = forecaster._align_statistics(statistics)
+    training_data = forecaster._build_training_data(statistics)
 
     # Only timestamps with all entities should be included
-    assert len(aligned) == 2
-    assert aligned[0][1] == {"sensor.input1": 10.0}
-    assert aligned[0][2] == pytest.approx(100.0)
-    assert aligned[1][1] == {"sensor.input1": 20.0}
-    assert aligned[1][2] == pytest.approx(200.0)
+    assert len(training_data) == 2
+    assert training_data[0][1] == {"sensor.input1": 10.0}
+    assert training_data[0][2] == pytest.approx(100.0)
+    assert training_data[1][1] == {"sensor.input1": 20.0}
+    assert training_data[1][2] == pytest.approx(200.0)
 
 
-def test_align_statistics_empty_when_no_common_timestamps(hass: HomeAssistant) -> None:
+def test_build_training_data_empty_when_no_common_timestamps(hass: HomeAssistant) -> None:
     """Returns empty list when no common timestamps exist."""
     entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
     forecaster = RiverMLForecaster(hass, entry)
@@ -226,12 +226,12 @@ def test_align_statistics_empty_when_no_common_timestamps(hass: HomeAssistant) -
         ],
     }
 
-    aligned = forecaster._align_statistics(statistics)
+    training_data = forecaster._build_training_data(statistics)
 
-    assert aligned == []
+    assert training_data == []
 
 
-def test_align_statistics_skips_none_values(hass: HomeAssistant) -> None:
+def test_build_training_data_skips_none_values(hass: HomeAssistant) -> None:
     """Skips entries with None start or mean values."""
     entry = _create_mock_entry(hass, input_entities=["sensor.input1"], output_entity="sensor.output")
     forecaster = RiverMLForecaster(hass, entry)
@@ -248,10 +248,10 @@ def test_align_statistics_skips_none_values(hass: HomeAssistant) -> None:
         ],
     }
 
-    aligned = forecaster._align_statistics(statistics)
+    training_data = forecaster._build_training_data(statistics)
 
-    assert len(aligned) == 1
-    assert aligned[0][1] == {"sensor.input1": 10.0}
+    assert len(training_data) == 1
+    assert training_data[0][1] == {"sensor.input1": 10.0}
 
 
 # Tests for model persistence

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,11 +8,18 @@ import pytest
 
 from custom_components.hafo.config_flow import HafoConfigFlow
 from custom_components.hafo.const import (
+    CONF_FORECAST_HOURS,
     CONF_FORECAST_TYPE,
     CONF_HISTORY_DAYS,
+    CONF_INPUT_ENTITIES,
+    CONF_OUTPUT_ENTITY,
+    CONF_RIVER_MODEL_TYPE,
     CONF_SOURCE_ENTITY,
-    DEFAULT_FORECAST_TYPE,
+    DEFAULT_FORECAST_HOURS,
     DEFAULT_HISTORY_DAYS,
+    DEFAULT_RIVER_MODEL_TYPE,
+    FORECAST_TYPE_HISTORICAL_SHIFT,
+    FORECAST_TYPE_RIVER_ML,
 )
 
 
@@ -34,21 +41,41 @@ async def test_user_flow_shows_form(hass: HomeAssistant, config_flow: HafoConfig
     assert result.get("step_id") == "user"
 
 
-async def test_user_flow_creates_entry(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
-    """Test that the user flow creates a config entry."""
-    # Set up a test entity
+async def test_user_flow_proceeds_to_historical_shift(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that selecting historical shift proceeds to that step."""
+    result = await config_flow.async_step_user(
+        user_input={CONF_FORECAST_TYPE: FORECAST_TYPE_HISTORICAL_SHIFT},
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "historical_shift"
+
+
+async def test_user_flow_proceeds_to_river_ml(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that selecting RiverML proceeds to that step."""
+    result = await config_flow.async_step_user(
+        user_input={CONF_FORECAST_TYPE: FORECAST_TYPE_RIVER_ML},
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "river_ml"
+
+
+async def test_historical_shift_creates_entry(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the historical shift step creates a config entry."""
     hass.states.async_set("sensor.test_power", "100.0", {"friendly_name": "Test Power"})
 
-    # Mock async_set_unique_id since it requires more context
     with (
         patch.object(config_flow, "async_set_unique_id", return_value=None),
         patch.object(config_flow, "_abort_if_unique_id_configured", return_value=None),
     ):
-        result = await config_flow.async_step_user(
+        # First, select forecast type
+        config_flow._data = {CONF_FORECAST_TYPE: FORECAST_TYPE_HISTORICAL_SHIFT}
+
+        result = await config_flow.async_step_historical_shift(
             user_input={
                 CONF_SOURCE_ENTITY: "sensor.test_power",
                 CONF_HISTORY_DAYS: 7,
-                CONF_FORECAST_TYPE: DEFAULT_FORECAST_TYPE,
             },
         )
 
@@ -57,18 +84,102 @@ async def test_user_flow_creates_entry(hass: HomeAssistant, config_flow: HafoCon
     data = dict(result.get("data", {}))
     assert data[CONF_SOURCE_ENTITY] == "sensor.test_power"
     assert data[CONF_HISTORY_DAYS] == 7
+    assert data[CONF_FORECAST_TYPE] == FORECAST_TYPE_HISTORICAL_SHIFT
 
 
-async def test_user_flow_entity_not_found(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
-    """Test that the user flow shows error for missing entity."""
-    # Submit with a non-existent entity
-    result = await config_flow.async_step_user(
+async def test_historical_shift_entity_not_found(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the historical shift step shows error for missing entity."""
+    result = await config_flow.async_step_historical_shift(
         user_input={
             CONF_SOURCE_ENTITY: "sensor.nonexistent",
             CONF_HISTORY_DAYS: DEFAULT_HISTORY_DAYS,
-            CONF_FORECAST_TYPE: DEFAULT_FORECAST_TYPE,
         },
     )
 
     assert result.get("type") == FlowResultType.FORM
     assert result.get("errors") == {CONF_SOURCE_ENTITY: "entity_not_found"}
+
+
+async def test_river_ml_creates_entry(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the RiverML step creates a config entry."""
+    hass.states.async_set("sensor.input1", "10.0", {"friendly_name": "Input 1"})
+    hass.states.async_set("sensor.input2", "20.0", {"friendly_name": "Input 2"})
+    hass.states.async_set("sensor.output", "100.0", {"friendly_name": "Output"})
+
+    with (
+        patch.object(config_flow, "async_set_unique_id", return_value=None),
+        patch.object(config_flow, "_abort_if_unique_id_configured", return_value=None),
+    ):
+        config_flow._data = {CONF_FORECAST_TYPE: FORECAST_TYPE_RIVER_ML}
+
+        result = await config_flow.async_step_river_ml(
+            user_input={
+                CONF_INPUT_ENTITIES: ["sensor.input1", "sensor.input2"],
+                CONF_OUTPUT_ENTITY: "sensor.output",
+                CONF_HISTORY_DAYS: 7,
+                CONF_FORECAST_HOURS: 48,
+                CONF_RIVER_MODEL_TYPE: DEFAULT_RIVER_MODEL_TYPE,
+            },
+        )
+
+    assert result.get("type") == FlowResultType.CREATE_ENTRY
+    assert result.get("title") == "Output RiverML Forecast"
+    data = dict(result.get("data", {}))
+    assert data[CONF_INPUT_ENTITIES] == ["sensor.input1", "sensor.input2"]
+    assert data[CONF_OUTPUT_ENTITY] == "sensor.output"
+    assert data[CONF_FORECAST_TYPE] == FORECAST_TYPE_RIVER_ML
+
+
+async def test_river_ml_no_input_entities(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the RiverML step shows error when no input entities provided."""
+    hass.states.async_set("sensor.output", "100.0")
+
+    result = await config_flow.async_step_river_ml(
+        user_input={
+            CONF_INPUT_ENTITIES: [],
+            CONF_OUTPUT_ENTITY: "sensor.output",
+            CONF_HISTORY_DAYS: DEFAULT_HISTORY_DAYS,
+            CONF_FORECAST_HOURS: DEFAULT_FORECAST_HOURS,
+            CONF_RIVER_MODEL_TYPE: DEFAULT_RIVER_MODEL_TYPE,
+        },
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {CONF_INPUT_ENTITIES: "no_input_entities"}
+
+
+async def test_river_ml_output_in_inputs(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the RiverML step shows error when output is in inputs."""
+    hass.states.async_set("sensor.input1", "10.0")
+    hass.states.async_set("sensor.output", "100.0")
+
+    result = await config_flow.async_step_river_ml(
+        user_input={
+            CONF_INPUT_ENTITIES: ["sensor.input1", "sensor.output"],  # Output is in inputs
+            CONF_OUTPUT_ENTITY: "sensor.output",
+            CONF_HISTORY_DAYS: DEFAULT_HISTORY_DAYS,
+            CONF_FORECAST_HOURS: DEFAULT_FORECAST_HOURS,
+            CONF_RIVER_MODEL_TYPE: DEFAULT_RIVER_MODEL_TYPE,
+        },
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {CONF_OUTPUT_ENTITY: "output_in_inputs"}
+
+
+async def test_river_ml_output_entity_not_found(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
+    """Test that the RiverML step shows error when output entity missing."""
+    hass.states.async_set("sensor.input1", "10.0")
+
+    result = await config_flow.async_step_river_ml(
+        user_input={
+            CONF_INPUT_ENTITIES: ["sensor.input1"],
+            CONF_OUTPUT_ENTITY: "sensor.nonexistent",
+            CONF_HISTORY_DAYS: DEFAULT_HISTORY_DAYS,
+            CONF_FORECAST_HOURS: DEFAULT_FORECAST_HOURS,
+            CONF_RIVER_MODEL_TYPE: DEFAULT_RIVER_MODEL_TYPE,
+        },
+    )
+
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("errors") == {CONF_OUTPUT_ENTITY: "entity_not_found"}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -148,25 +148,6 @@ async def test_river_ml_no_input_entities(hass: HomeAssistant, config_flow: Hafo
     assert result.get("errors") == {CONF_INPUT_ENTITIES: "no_input_entities"}
 
 
-async def test_river_ml_output_in_inputs(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
-    """Test that the RiverML step shows error when output is in inputs."""
-    hass.states.async_set("sensor.input1", "10.0")
-    hass.states.async_set("sensor.output", "100.0")
-
-    result = await config_flow.async_step_river_ml(
-        user_input={
-            CONF_INPUT_ENTITIES: ["sensor.input1", "sensor.output"],  # Output is in inputs
-            CONF_OUTPUT_ENTITY: "sensor.output",
-            CONF_HISTORY_DAYS: DEFAULT_HISTORY_DAYS,
-            CONF_FORECAST_HOURS: DEFAULT_FORECAST_HOURS,
-            CONF_RIVER_MODEL_TYPE: DEFAULT_RIVER_MODEL_TYPE,
-        },
-    )
-
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {CONF_OUTPUT_ENTITY: "output_in_inputs"}
-
-
 async def test_river_ml_output_entity_not_found(hass: HomeAssistant, config_flow: HafoConfigFlow) -> None:
     """Test that the RiverML step shows error when output entity missing."""
     hass.states.async_set("sensor.input1", "10.0")

--- a/uv.lock
+++ b/uv.lock
@@ -1094,7 +1094,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2025.12.2" },
-    { name = "river", specifier = ">=0.22.0" },
+    { name = "river", specifier = ">=0.23.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -1061,6 +1061,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },
+    { name = "river" },
 ]
 
 [package.dev-dependencies]
@@ -1091,7 +1092,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "homeassistant", specifier = ">=2025.12.2" }]
+requires-dist = [
+    { name = "homeassistant", specifier = ">=2025.12.2" },
+    { name = "river", specifier = ">=0.22.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2032,6 +2036,33 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "2.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
+    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
+    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
+    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
+    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
+    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2778,6 +2809,27 @@ wheels = [
 ]
 
 [[package]]
+name = "river"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/38/9063e6410a14c3ad37b943018d1de202a0e4e288a04cf7fb8fff392c6e4b/river-0.23.0.tar.gz", hash = "sha256:f174cb8e5984be1a193827faf8e09a03ceb110a055290628accc72ec987390f1", size = 1406568, upload-time = "2025-11-13T19:25:11.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/43/99183a1718c14a4876de8aa944f8435c169339b2cae01712a13049254e19/river-0.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:672281a91f872d9fe4ecbe9d85e738160c81e5b049404befeada050e5a51269e", size = 2455255, upload-time = "2025-11-13T19:24:56.142Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/93/0600ee91be2e55a806369a08bc1cf25fb52b185ffc5c5f099960f995ba65/river-0.23.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a690a546257dae7a7884a6471502e935b5b492c6884eab97e1aaadf8905ba462", size = 3175421, upload-time = "2025-11-13T19:24:58.105Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f0/7a41649b5799dc6bf32e925a4f2348929020acb1f7effb74a3b4042825d1/river-0.23.0-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:1374c7b6c989b2409f96158f99af4d1c97ff5e84828ebf2223baed51284a0b9c", size = 3148855, upload-time = "2025-11-13T19:25:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/29/05/42e02b34e8890e5e5b557ae6c0ff92fd11bea4a9b56da146dc17214174c2/river-0.23.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d525d20bfa20b21ca1eafb81d64f12eb716618267cf1a741c747aa44ac271fe5", size = 3202437, upload-time = "2025-11-13T19:25:01.605Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8c/60c1de1520823432badb33063b19ba59ed46c877d44518fe78f945f51c14/river-0.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:040cfbc8a166b913c5d31224f5871ae2483c72b2b786e869ba90909496b72e1a", size = 4100515, upload-time = "2025-11-13T19:25:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/79/5229ddc2a0df221c4e5646b8f1fbece8b66f0184c06c2fb101bab5525609/river-0.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d3ea141087232b75440ced85cd278eb8c2effe7ea69a0d269d5f95110945b92", size = 4193101, upload-time = "2025-11-13T19:25:05.629Z" },
+    { url = "https://files.pythonhosted.org/packages/13/92/5cb1fcaea30e74610f8b1f3f93ee68bd2b2127a8c37e5222ec57d76425d3/river-0.23.0-cp313-cp313-win32.whl", hash = "sha256:e33f54124b5738d2211d712c902fb99d87b4b3219d19374954b911a3980276ee", size = 1794333, upload-time = "2025-11-13T19:25:07.751Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a8/2a0791379ddd6bfa596219ff0e8647f8df50018951ec1f297863129a52bc/river-0.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:62df6da5bc11a6b88ec2c7be9836661e64475ba920695547e436d0fb0b3b7d4d", size = 1832780, upload-time = "2025-11-13T19:25:09.469Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2880,6 +2932,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/ca/d8ace4f98322d01abcd52d381134344bf7b431eba7ed8b42bdea5a3c2ac9/scipy-1.16.3.tar.gz", hash = "sha256:01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb", size = 30597883, upload-time = "2025-10-28T17:38:54.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/f1/57e8327ab1508272029e27eeef34f2302ffc156b69e7e233e906c2a5c379/scipy-1.16.3-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:d2ec56337675e61b312179a1ad124f5f570c00f920cc75e1000025451b88241c", size = 36617856, upload-time = "2025-10-28T17:33:31.375Z" },
+    { url = "https://files.pythonhosted.org/packages/44/13/7e63cfba8a7452eb756306aa2fd9b37a29a323b672b964b4fdeded9a3f21/scipy-1.16.3-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:16b8bc35a4cc24db80a0ec836a9286d0e31b2503cb2fd7ff7fb0e0374a97081d", size = 28874306, upload-time = "2025-10-28T17:33:36.516Z" },
+    { url = "https://files.pythonhosted.org/packages/15/65/3a9400efd0228a176e6ec3454b1fa998fbbb5a8defa1672c3f65706987db/scipy-1.16.3-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:5803c5fadd29de0cf27fa08ccbfe7a9e5d741bf63e4ab1085437266f12460ff9", size = 20865371, upload-time = "2025-10-28T17:33:42.094Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/eda09adf009a9fb81827194d4dd02d2e4bc752cef16737cc4ef065234031/scipy-1.16.3-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:b81c27fc41954319a943d43b20e07c40bdcd3ff7cf013f4fb86286faefe546c4", size = 23524877, upload-time = "2025-10-28T17:33:48.483Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/6b/3f911e1ebc364cb81320223a3422aab7d26c9c7973109a9cd0f27c64c6c0/scipy-1.16.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0c3b4dd3d9b08dbce0f3440032c52e9e2ab9f96ade2d3943313dfe51a7056959", size = 33342103, upload-time = "2025-10-28T17:33:56.495Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f6/4bfb5695d8941e5c570a04d9fcd0d36bce7511b7d78e6e75c8f9791f82d0/scipy-1.16.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7dc1360c06535ea6116a2220f760ae572db9f661aba2d88074fe30ec2aa1ff88", size = 35697297, upload-time = "2025-10-28T17:34:04.722Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6496dadbc80d8d896ff72511ecfe2316b50313bfc3ebf07a3f580f08bd8c/scipy-1.16.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:663b8d66a8748051c3ee9c96465fb417509315b99c71550fda2591d7dd634234", size = 36021756, upload-time = "2025-10-28T17:34:13.482Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/bd/a8c7799e0136b987bda3e1b23d155bcb31aec68a4a472554df5f0937eef7/scipy-1.16.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eab43fae33a0c39006a88096cd7b4f4ef545ea0447d250d5ac18202d40b6611d", size = 38696566, upload-time = "2025-10-28T17:34:22.384Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/01/1204382461fcbfeb05b6161b594f4007e78b6eba9b375382f79153172b4d/scipy-1.16.3-cp313-cp313-win_amd64.whl", hash = "sha256:062246acacbe9f8210de8e751b16fc37458213f124bef161a5a02c7a39284304", size = 38529877, upload-time = "2025-10-28T17:35:51.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/14/9d9fbcaa1260a94f4bb5b64ba9213ceb5d03cd88841fe9fd1ffd47a45b73/scipy-1.16.3-cp313-cp313-win_arm64.whl", hash = "sha256:50a3dbf286dbc7d84f176f9a1574c705f277cb6565069f88f60db9eafdbe3ee2", size = 25455366, upload-time = "2025-10-28T17:35:59.014Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a3/9ec205bd49f42d45d77f1730dbad9ccf146244c1647605cf834b3a8c4f36/scipy-1.16.3-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:fb4b29f4cf8cc5a8d628bc8d8e26d12d7278cd1f219f22698a378c3d67db5e4b", size = 37027931, upload-time = "2025-10-28T17:34:31.451Z" },
+    { url = "https://files.pythonhosted.org/packages/25/06/ca9fd1f3a4589cbd825b1447e5db3a8ebb969c1eaf22c8579bd286f51b6d/scipy-1.16.3-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:8d09d72dc92742988b0e7750bddb8060b0c7079606c0d24a8cc8e9c9c11f9079", size = 29400081, upload-time = "2025-10-28T17:34:39.087Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/56/933e68210d92657d93fb0e381683bc0e53a965048d7358ff5fbf9e6a1b17/scipy-1.16.3-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:03192a35e661470197556de24e7cb1330d84b35b94ead65c46ad6f16f6b28f2a", size = 21391244, upload-time = "2025-10-28T17:34:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/7e/779845db03dc1418e215726329674b40576879b91814568757ff0014ad65/scipy-1.16.3-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:57d01cb6f85e34f0946b33caa66e892aae072b64b034183f3d87c4025802a119", size = 23929753, upload-time = "2025-10-28T17:34:51.793Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4b/f756cf8161d5365dcdef9e5f460ab226c068211030a175d2fc7f3f41ca64/scipy-1.16.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:96491a6a54e995f00a28a3c3badfff58fd093bf26cd5fb34a2188c8c756a3a2c", size = 33496912, upload-time = "2025-10-28T17:34:59.8Z" },
+    { url = "https://files.pythonhosted.org/packages/09/b5/222b1e49a58668f23839ca1542a6322bb095ab8d6590d4f71723869a6c2c/scipy-1.16.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cd13e354df9938598af2be05822c323e97132d5e6306b83a3b4ee6724c6e522e", size = 35802371, upload-time = "2025-10-28T17:35:08.173Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8d/5964ef68bb31829bde27611f8c9deeac13764589fe74a75390242b64ca44/scipy-1.16.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:63d3cdacb8a824a295191a723ee5e4ea7768ca5ca5f2838532d9f2e2b3ce2135", size = 36190477, upload-time = "2025-10-28T17:35:16.7Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f2/b31d75cb9b5fa4dd39a0a931ee9b33e7f6f36f23be5ef560bf72e0f92f32/scipy-1.16.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e7efa2681ea410b10dde31a52b18b0154d66f2485328830e45fdf183af5aefc6", size = 38796678, upload-time = "2025-10-28T17:35:26.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1e/b3723d8ff64ab548c38d87055483714fefe6ee20e0189b62352b5e015bb1/scipy-1.16.3-cp313-cp313t-win_amd64.whl", hash = "sha256:2d1ae2cf0c350e7705168ff2429962a89ad90c2d49d1dd300686d8b2a5af22fc", size = 38640178, upload-time = "2025-10-28T17:35:35.304Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f3/d854ff38789aca9b0cc23008d607ced9de4f7ab14fa1ca4329f86b3758ca/scipy-1.16.3-cp313-cp313t-win_arm64.whl", hash = "sha256:0c623a54f7b79dd88ef56da19bc2873afec9673a48f3b85b18e4d402bdd29a5a", size = 25803246, upload-time = "2025-10-28T17:35:42.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request adds support for a new "RiverML" forecast type to the Home Assistant Forecaster integration and introduces a shared utilities module for forecast models. It also refactors the codebase to use common types and statistics-fetching utilities, improving maintainability and extensibility for future forecasters.
